### PR TITLE
output profile, region, resource name

### DIFF
--- a/Classic-Resource-Finder.sh
+++ b/Classic-Resource-Finder.sh
@@ -16,6 +16,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+profile=${AWS_PROFILE:-default}
+header=${OUTPUT_HEADER:-1}
 
 ## Unset a bunch of variables we will use later
 unset awscurrentversion awsversionregex jqtest cuttest region classicstatus ec2next ec2loopcounter ec2raw sgnext sgloopcounter sgraw asgnext asgloopcounter \
@@ -45,18 +47,20 @@ fi
 
 ## Search for EC2-Classic Resources
 declare -a regions=('us-east-1' 'eu-west-1' 'us-west-1' 'ap-southeast-1' 'ap-northeast-1' 'us-west-2' 'sa-east-1' 'ap-southeast-2') ## Define regions that support EC2-Classic
+i=0
 for region in "${regions[@]}" ## Loop through the regions that support EC2-Classic
 do
     printf "# -------------------------------------------------------------------------\nSearching for resources in EC2-Classic in $region\n# -------------------------------------------------------------------------\n\n"
 
     ## Get Enablement Status
     printf "Determining if EC2-Classic is enabled..."
+    [[ $header == 0 ]] || echo "profile,region,status" >> Classic_Platform_Status.csv
     classicstatus=`aws ec2 describe-account-attributes --attribute-names supported-platforms --region $region --output json 2>> errors.txt` ## Get supported platforms for the region.
     if [[ ${#classicstatus} -gt 2 ]] ## Make sure we got a return value
         then classicstatusfiltered=`jq -r '.AccountAttributes[] .AttributeValues[] | select(.AttributeValue=="EC2") | .AttributeValue' <<< $classicstatus 2>> errors.txt` ##Filter the input to determine if EC2 (classic) is supported
             if [[ ${#classicstatusfiltered} -gt 2 ]]
-                then printf "$region, Enabled\n" >> Classic_Platform_Status.csv ## If supported platforms includes EC2 in addition to VPC, output the region and Enabled to a CSV
-                else printf "$region, Disabled\n" >> Classic_Platform_Status.csv ## If supported platforms is only VPC and does not include EC2, output the region and Disabled to a CSV
+                then printf "$profile,$region,Enabled\n" >> Classic_Platform_Status.csv ## If supported platforms includes EC2 in addition to VPC, output the region and Enabled to a CSV
+                else printf "$profile,$region,Disabled\n" >> Classic_Platform_Status.csv ## If supported platforms is only VPC and does not include EC2, output the region and Disabled to a CSV
             fi
         else printf "$region, Unknown\n" >> Classic_Platform_Status.csv
     fi
@@ -64,100 +68,114 @@ do
 
     ## Search for EIPs
     printf "Searching for EIPs in EC2-Classic..."
-    aws ec2 describe-addresses --filters Name=domain,Values=standard --region $region --output json 2>> errors.txt | jq -r --arg region ",$region" '.Addresses[] .PublicIp + $region' >> Classic_EIPs.csv  ## Get all EIPs in EC2-Classic and output them with their corresponding region to a CSV
+    [[ $header == 0 ]] || echo "profile,region,PublicIp,InstanceId" >> Classic_EIPs.csv
+    aws ec2 describe-addresses \
+     --filters Name=domain,Values=standard \
+     --region $region \
+     --output json 2>> errors.txt \
+     | jq -r --arg profile "$profile" --arg region "$region" \
+     '.Addresses[] | [$profile, $region, .PublicIp, .InstanceId] | @csv' >> Classic_EIPs.csv  ## Get all EIPs in EC2-Classic and output them with their corresponding region to a CSV
     printf "Done \xe2\x9c\x85 \n"
+
 
     ## Search for EC2 Instances
     printf "Searching for any EC2-Classic instances..."
+    [[ $header == 0 ]] || echo "profile,region,Name,InstanceId,InstanceType" >> Classic_EC2_Instances.csv
     ec2next="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i ec2loopcounter ## Set a variable as int for loop counter
     ec2loopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#ec2next} -gt 10 ]] && [[ $ec2loopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#ec2next} -gt 10 ]] && [[ $ec2loopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $ec2next == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then ec2raw=`aws ec2 describe-instances --region $region --filter Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped --query '{NextToken:NextToken,Reservations:Reservations[*].Instances[?VpcId==\`null\`]}' --output json 2>> errors.txt` ## Get the NextToken and InstanceID in JSON and store it in a variable
             else ec2raw=`aws ec2 describe-instances --region $region --filter Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped --query '{NextToken:NextToken,Reservations:Reservations[*].Instances[?VpcId==\`null\`]}' --starting-token $ec2next --output json 2>> errors.txt` ## Get the NextToken and InstanceID in in JSON starting at the current token value and store it in a variable
         fi
         ec2next=`jq -r '.NextToken' <<< $ec2raw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
-        jq -r --arg region ",$region" '.Reservations[] | .[] .InstanceId + $region' <<< $ec2raw >> Classic_EC2_Instances.csv ## Parse the instance IDs, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.Reservations[] | .[] | [$profile, $region, (.Tags[] | select(.[] == "Name").Value), .InstanceId, .InstanceType] | @csv' <<< $ec2raw >> Classic_EC2_Instances.csv ## Parse the instance IDs, append the region to each line delimited by a comma and output to the CSV
         ec2loopcounter=$((ec2loopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
 
     ## Search for Security Groups
     printf "Searching for any Security Groups not in a VPC..."
+    [[ $header == 0 ]] || echo "profile,region,GroupName,GroupId" >> Classic_SGs.csv
     sgnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i sgloopcounter ## Set a variable as int for loop counter
     sgloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#sgnext} -gt 10 ]] && [[ $sgloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#sgnext} -gt 10 ]] && [[ $sgloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $sgnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
-            then sgraw=`aws ec2 describe-security-groups --query '{NextToken:NextToken,SecurityGroups:SecurityGroups[?VpcId==\`null\`].GroupId}' --region $region --output json 2>> errors.txt` ## Get the NextToken and Security GroupID in JSON and store it in a variable
-            else sgraw=`aws ec2 describe-security-groups --query '{NextToken:NextToken,SecurityGroups:SecurityGroups[?VpcId==\`null\`].GroupId}' --region $region --output json --starting-token $sgnext 2>> errors.txt` ## Get the NextToken and Security GroupID in in JSON starting at the current token value and store it in a variable
+            then sgraw=`aws ec2 describe-security-groups --query '{NextToken:NextToken,SecurityGroups:SecurityGroups[?VpcId==\`null\`]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and Security GroupID in JSON and store it in a variable
+            else sgraw=`aws ec2 describe-security-groups --query '{NextToken:NextToken,SecurityGroups:SecurityGroups[?VpcId==\`null\`]}' --region $region --output json --starting-token $sgnext 2>> errors.txt` ## Get the NextToken and Security GroupID in in JSON starting at the current token value and store it in a variable
         fi
         sgnext=`jq -r '.NextToken' <<< $sgraw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
-        jq -r --arg region ",$region" '.SecurityGroups[] + $region' <<< $sgraw >> Classic_SGs.csv ## Parse the Security Group IDs, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.SecurityGroups[] | [$profile, $region, .GroupName, .GroupId] | @csv' <<< $sgraw >> Classic_SGs.csv ## Parse the Security Group IDs, append the region to each line delimited by a comma and output to the CSV
         sgloopcounter=$((sgloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
 
     ## Search VPC Classic Links
     printf "Searching for VPCs with ClassicLink Enabled..."
-    aws ec2 describe-vpc-classic-link --filter "Name=is-classic-link-enabled,Values=true" --region $region --output json 2>> errors.txt | jq -r --arg region ",$region" '.Vpcs[] .VpcId + $region' >> Classic_ClassicLink_VPCs.csv ## Get all VPC IDs with ClassicLink emabled and output them with their corresponding region to a CSV
+    [[ $header == 0 ]] || echo "profile,region,VpcId" >> Classic_ClassicLink_VPCs.csv
+    aws ec2 describe-vpc-classic-link --filter "Name=is-classic-link-enabled,Values=true" --region $region --output json 2>> errors.txt \
+    | jq -r --arg profile "$profile" --arg region "$region" '.Vpcs[] | [$profile, $region, .VpcId] | @csv' >> Classic_ClassicLink_VPCs.csv ## Get all VPC IDs with ClassicLink emabled and output them with their corresponding region to a CSV
     printf "Done \xe2\x9c\x85 \n"
 
     ## Search for Auto-Scaling Groups
     printf "Searching for Auto-Scaling groups without a VPC configured..."
+    [[ $header == 0 ]] || echo "profile,region,AutoScalingGroupARN" >> Classic_Auto_Scaling_Groups.csv
     asgnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i asgloopcounter ## Set a variable as int for loop counter
     asgloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#asgnext} -gt 10 ]] && [[ $asgloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#asgnext} -gt 10 ]] && [[ $asgloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $asgnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then asgraw=`aws autoscaling describe-auto-scaling-groups --query '{NextToken:NextToken,AutoScalingGroups:AutoScalingGroups[?VPCZoneIdentifier==\`\`]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and ASG ARN in JSON and store it in a variable
             else asgraw=`aws autoscaling describe-auto-scaling-groups --query '{NextToken:NextToken,AutoScalingGroups:AutoScalingGroups[?VPCZoneIdentifier==\`\`]}' --region $region --output json --starting-token $asgnext 2>> errors.txt` ## Get the NextToken and ASG ARN in in JSON starting at the current token value and store it in a variable
         fi
         asgnext=`jq -r '.NextToken' <<< $asgraw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
-        jq -r --arg region ",$region" '.AutoScalingGroups[] .AutoScalingGroupARN + $region' <<< $asgraw >> Classic_Auto_Scaling_Groups.csv ## Parse the ASG ARN, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.AutoScalingGroups[] | [$profile, $region, .AutoScalingGroupARN] | @csv' <<< $asgraw >> Classic_Auto_Scaling_Groups.csv ## Parse the ASG ARN, append the region to each line delimited by a comma and output to the CSV
         asgloopcounter=$((asgloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Search for CLBs
     printf "Searching for any Classic Load Balancer in EC2-Classic..."
+    [[ $header == 0 ]] || echo "profile,region,LoadBalancerName" >> Classic_CLBs.csv
     clbnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i clbloopcounter ## Set a variable as int for loop counter
     clbloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#clbnext} -gt 10 ]] && [[ $clbloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#clbnext} -gt 10 ]] && [[ $clbloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $clbnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then clbraw=`aws elb describe-load-balancers --query '{NextMarker:NextMarker,LoadBalancerName:LoadBalancerDescriptions[?VPCId==\`null\`]}' --region $region --output json 2>> errors.txt` ## Get the NextMarker and CLB Name in JSON and store it in a variable
             else clbraw=`aws elb describe-load-balancers --query '{NextMarker:NextMarker,LoadBalancerName:LoadBalancerDescriptions[?VPCId==\`null\`]}' --region $region --starting-token $clbnext --output json 2>> errors.txt` ## Get the NextMarker and CLB Name in in JSON starting at the current token value and store it in a variable
         fi
         clbnext=`jq -r '.NextMarker' <<< $clbraw 2>> errors.txt` ## Use JQ to parse the NextMarker and store it in a variable
-        jq -r --arg region ",$region" '.LoadBalancerName[] .LoadBalancerName + $region' <<< $clbraw 2>> errors.txt >> Classic_CLBs.csv ## Parse the CLB Name, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.LoadBalancerName[] | [$profile, $region, .LoadBalancerName] | @csv' <<< $clbraw 2>> errors.txt >> Classic_CLBs.csv ## Parse the CLB Name, append the region to each line delimited by a comma and output to the CSV
         clbloopcounter=$((clbloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
 
     ## Search for RDS DBs
     printf "Searching for any RDS-Classic instances..."
+    [[ $header == 0 ]] || echo "profile,region,DBInstanceArn" >> Classic_RDS_Instances.csv
     rdsnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i rdsloopcounter ## Set a variable as int for loop counter
     rdsloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#rdsnext} -gt 10 ]] && [[ $rdsloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#rdsnext} -gt 10 ]] && [[ $rdsloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $rdsnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then rdsraw=`aws rds describe-db-instances --query '{NextToken:NextToken,DBInstanceArn:DBInstances[*].DBInstanceArn}' --region $region --output json 2>> errors.txt` ## Get the NextToken and DB ARN in JSON and store it in a variable
             else rdsraw=`aws rds describe-db-instances --query '{NextToken:NextToken,DBInstanceArn:DBInstances[*].DBInstanceArn}' --region $region --starting-token $rdsnext --output json 2>> errors.txt` ## Get the NextToken and DB ARN in in JSON starting at the current token value and store it in a variable
         fi
-       
+
         rdsnext=`jq -r '.NextToken' <<< $rdsraw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
         for dbinstance in `jq -r '.DBInstanceArn[]' <<< $rdsraw 2>> errors.txt` ## Loop through all DB Instances
-        do 
+        do
             instancesg=`aws rds describe-db-instances --filters Name=db-instance-id,Values=$dbinstance --query 'DBInstances[*].VpcSecurityGroups[*].VpcSecurityGroupId' --region $region --output text 2>> errors.txt` ## Get the VPC Security Group ID[s] attached. If it is classic, this will be empty.
             if [[ ${#instancesg} -lt 5 ]] ## If the return is empty, thus classic then:
-                then printf "$dbinstance, $region \n" >> Classic_RDS_Instances.csv ## Print the DB Instance ARN and Region and output it to a CSV
+                then printf "$profile,$region,$dbinstance \n" >> Classic_RDS_Instances.csv ## Print the DB Instance ARN and Region and output it to a CSV
             fi
             unset instancesg ## Clean up our variable from this loop
         done
@@ -168,44 +186,47 @@ do
 
     ## Search for ElastiCache Clusters
     printf "Searching for any Elasticache clusters not in a VPC..."
+    [[ $header == 0 ]] || echo "profile,region,ARN" >> Classic_ElastiCache_Clusters.csv
     ecachenext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i ecacheloopcounter ## Set a variable as int for loop counter
     ecacheloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#ecachenext} -gt 10 ]] && [[ $ecacheloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#ecachenext} -gt 10 ]] && [[ $ecacheloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $ecachenext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then ecacheraw=`aws elasticache describe-cache-clusters --query '{NextToken:NextToken,ARN:CacheClusters[?CacheSubnetGroupName==\`null\`]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and Cluster ARN in JSON and store it in a variable
             else ecacheraw=`aws elasticache describe-cache-clusters --query '{NextToken:NextToken,ARN:CacheClusters[?CacheSubnetGroupName==\`null\`]}' --region $region --starting-token $ecachenext --output json 2>> errors.txt` ## Get the NextToken and Cluster ARN in in JSON starting at the current token value and store it in a variable
         fi
         ecachenext=`jq -r '.NextToken' <<< $ecacheraw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
-        jq -r --arg region ",$region" '.ARN[] .ARN + $region' <<< $ecacheraw 2>> errors.txt >> Classic_ElastiCache_Clusters.csv ## Parse the Cluster ARN, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.ARN[] | [$profile, $region, .ARN] | @csv' <<< $ecacheraw 2>> errors.txt >> Classic_ElastiCache_Clusters.csv ## Parse the Cluster ARN, append the region to each line delimited by a comma and output to the CSV
         ecacheloopcounter=$((ecacheloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
 
     ## Search for Redshift Cluster
     printf "Searching for any Redshift clusters not in a VPC..."
+    [[ $header == 0 ]] || echo "profile,region,ClusterIdentifier" >> Classic_Redshift_Clusters.csv
     redshiftnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i redshiftloopcounter ## Set a variable as int for loop counter
     redshiftloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#redshiftnext} -gt 10 ]] && [[ $redshiftloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#redshiftnext} -gt 10 ]] && [[ $redshiftloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $redshiftnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then redshiftraw=`aws redshift describe-clusters --query '{NextToken:NextToken,ClusterIdentifier:Clusters[?VpcId==\`null\`]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and Cluster Identifier in JSON and store it in a variable
             else redshiftraw=`aws redshift describe-clusters --query '{NextToken:NextToken,ClusterIdentifier:Clusters[?VpcId==\`null\`]}' --region $region --starting-token $redshiftnext --output json 2>> errors.txt` ## Get the NextToken and Cluster Identifier in in JSON starting at the current token value and store it in a variable
         fi
         redshiftnext=`jq -r '.NextToken' <<< $redshiftraw 2>> errors.txt` ## Use JQ to parse the NextToken and store it in a variable
-        jq -r --arg region ",$region" '.ClusterIdentifier[] .ClusterIdentifier + $region' <<< $redshiftraw 2>> errors.txt >> Classic_Redshift_Clusters.csv ## Parse the Cluster Identifier, append the region to each line delimited by a comma and output to the CSV
+        jq -r --arg profile "$profile" --arg region "$region" '.ClusterIdentifier[] | [$profile, $region, .ClusterIdentifier] | @csv' <<< $redshiftraw 2>> errors.txt >> Classic_Redshift_Clusters.csv ## Parse the Cluster Identifier, append the region to each line delimited by a comma and output to the CSV
         redshiftloopcounter=$((redshiftloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Search for ElasticBeanstalk Environments
     printf "Searching for any ElasticBeanstalk Environments without a VPC..."
+    [[ $header == 0 ]] || echo "profile,region,application-name,environment-name" >> Classic_ElasticBeanstalk_Applications_Environments.csv
     ebappnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i ebapploopcounter ## Set a variable as int for loop counter
     ebapploopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#ebappnext} -gt 10 ]] && [[ $ebapploopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#ebappnext} -gt 10 ]] && [[ $ebapploopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $ebappnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then ebappraw=`aws elasticbeanstalk describe-environments --no-include-deleted --query '{NextToken:NextToken,Environments:Environments[*]}' --region $region  --output json 2>> errors.txt` ## Get the NextToken and environment values in JSON and store it in a variable
@@ -220,7 +241,7 @@ do
             ebnsval=`aws elasticbeanstalk describe-configuration-settings --application-name $ebapp --environment-name $ebenv --query 'ConfigurationSettings[*].OptionSettings[?Namespace==\`aws:ec2:vpc\`&&OptionName==\`VPCId\`&&Value!=\`null\`].OptionName' --region $region --output text 2>> errors.txt` ## If the environment is configured for a vpc return "VPCId"
             ebnsvalregex="VPCId"
             if [[ ! $ebnsval == $ebnsvalregex ]] ## If the configuration does not have a VPC:
-                then printf "$ebapp, $ebenv, $region\n" >> Classic_ElasticBeanstalk_Applications_Environments.csv ## Return the Application Name, Environment Name and Region for EB that doesnt have a VPC
+                then printf "$profile,$region,$ebapp,$ebenv\n" >> Classic_ElasticBeanstalk_Applications_Environments.csv ## Return the Application Name, Environment Name and Region for EB that doesnt have a VPC
             fi
             unset ebapp
             unset ebenv
@@ -231,13 +252,14 @@ do
         unset ebenvapp
     done
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Search for DataPipelines
     printf "Searching for any DataPipelines that dont have subnets associated..."
+    [[ $header == 0 ]] || echo "profile,region,pipeline-id" >> Classic_DataPipelines.csv
     dpnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i dploopcounter ## Set a variable as int for loop counter
     dploopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#dpnext} -gt 10 ]] && [[ $dploopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#dpnext} -gt 10 ]] && [[ $dploopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $dpnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then dpraw=`aws datapipeline list-pipelines --query '{NextToken:NextToken,id:pipelineIdList[*]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and Pipeline ID in JSON and store it in a variable
@@ -249,7 +271,7 @@ do
             dpdefinition=`aws datapipeline get-pipeline-definition --pipeline-id $pipeline --query 'objects[?type==\`Ec2Resource\`&&subnetId==\`null\`].type' --region $region --output text 2>> errors.txt` ## Return "Ec2Resource" only if the ec2 resource subnet ID is null
             dpdefinitionregex="Ec2Resource"
             if [[ $dpdefinition == $dpdefinitionregex ]]
-                then printf "$pipeline, $region\n" >> Classic_DataPipelines.csv ## Return the Pipeline ID and region and output it to a CSV
+                then printf "$profile,$region,$pipeline\n" >> Classic_DataPipelines.csv ## Return the Pipeline ID and region and output it to a CSV
             fi
             unset dpdefinition
             unset dpdefinitionregex
@@ -259,13 +281,14 @@ do
         dploopcounter=$((dploopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Search for EMR Clusters
     printf "Searching for EMR clusters not configured to launch in a subnet..."
+    [[ $header == 0 ]] || echo "profile,region,cluster-id" >> Classic_EMR_Clusters.csv
     emrnext="placeholder" ## Set a placeholder value for pagination token so the while loop kicks in. It gets dropped later in an IF statement.
     declare -i emrloopcounter ## Set a variable as int for loop counter
     emrloopcounter=1 ## Set the loop counter value to 1
-    while [[ ${#emrnext} -gt 10 ]] && [[ $emrloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100 
+    while [[ ${#emrnext} -gt 10 ]] && [[ $emrloopcounter -lt 100 ]] ## While the next token is not empty or "null" and the loopcounter is less than 100
         do
         if [[ $emrnext == "placeholder" ]] ## If token is still the placeholder, dont pass a starting-token else pass the starting token
             then emrraw=`aws emr list-clusters --active --query '{NextToken:NextToken,id:Clusters[*]}' --region $region --output json 2>> errors.txt` ## Get the NextToken and cluster ID in JSON and store it in a variable
@@ -277,8 +300,8 @@ do
             emrclustconfig=`aws emr describe-cluster --cluster-id $emrclust --query 'Cluster.Ec2InstanceAttributes' --region $region --output json 2>> errors.txt` ## Get "true" for clusters that don't have a VPC subnet configured and "false" for ones that do have a subnet configured
             emrsubnetid=`jq -r '.Ec2SubnetId' <<< $emrclustconfig 2>> errors.txt`
             emrrequestedsubnetids=`jq -r '.RequestedEc2SubnetIds[]' <<< $emrclustconfig 2>> errors.txt`
-            if [[ ${#emrsubnetid} -lt 10 ]] && [[ ${#emrrequestedsubnetids} -lt 10 ]] ## If the cluster doesn't have a subnet configured then: 
-                then printf "$emrclust, $region\n" >> Classic_EMR_Clusters.csv ## Return the Cluster ID and region and output it to a CSV
+            if [[ ${#emrsubnetid} -lt 10 ]] && [[ ${#emrrequestedsubnetids} -lt 10 ]] ## If the cluster doesn't have a subnet configured then:
+                then printf "$profile,$region,$emrclust\n" >> Classic_EMR_Clusters.csv ## Return the Cluster ID and region and output it to a CSV
             fi
             unset emrsubnetid
             unset emrrequestedsubnetids
@@ -289,12 +312,14 @@ do
         emrloopcounter=$((emrloopcounter + 1))
     done
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Search for OpsWorks Stacks
     printf "Searching for OpsWorks stacks with resources in EC2-Classic..."
-    aws opsworks describe-stacks --query 'Stacks[?VpcId==`null`]' --region $region --output json 2>> errors.txt | jq -r --arg region ",$region" '.[] .StackId + $region' >> Classic_OpsWorks_Stacks.csv ## Get all OpsWorks Stacks in EC2-Classic and output them with their corresponding region to a CSV
+    [[ $header == 0 ]] || echo "profile,region,StackId" >> Classic_OpsWorks_Stacks.csv
+    aws opsworks describe-stacks --query 'Stacks[?VpcId==`null`]' --region $region --output json 2>> errors.txt \
+    | jq -r --arg profile "$profile" --arg region ",$region" '.[] | [$profile, $region, .StackId] | @csv' >> Classic_OpsWorks_Stacks.csv ## Get all OpsWorks Stacks in EC2-Classic and output them with their corresponding region to a CSV
     printf "Done \xe2\x9c\x85 \n"
-    
+
     ## Unset all the variables we used within the region loop
     unset classicstatus ec2next ec2loopcounter ec2raw sgnext sgloopcounter sgraw asgnext asgloopcounter \
         asgraw clbnext clbloopcounter clbraw rdsnext rdsloopcounter rdsraw ecachenext ecacheloopcounter ecacheraw redshiftnext redshiftloopcounter redshiftraw ebappnext \
@@ -302,10 +327,16 @@ do
         emrraw emrclust emrclustconfig emrsubnetid emrrequestedsubnetids
 
     printf "\n# -------------------------------------------------------------------------\nSearch for resources in $region is complete\n# -------------------------------------------------------------------------\n\n\n\n"
+
+    if [ $i == 0 ]; then
+        header=0
+        i=$(($i+1))
+    fi
+
 done
 
 ## Unset all the variables we used outside of and for the region loop
-unset awscurrentversion awsversionregex jqtest cuttest region 
+unset awscurrentversion awsversionregex jqtest cuttest region
 
 printf "Search for EC2-Classic Resources is complete! Please check for the CSVs output to this directory."
 printf "If no resources were found in EC2-Classic for a service, empty CSVs were created with no resources except for Classic_Platform_Status.csv which shows the current status of all regions."


### PR DESCRIPTION
NOTE: this repo is **public** . don't commit **sensitive value** .

## Fixes

Classic-Resource-Finder.sh
- output profile, region, resource name
- OUTPUT_HEADER option
```shell
export AWS_PROFILE=example
# if disable header
export OUTPUT_HEADER=0

./Classic-Resource-Finder.sh
```


multi-account-wrapper.sh
- Supports cases where the organizations account has a separate STS account
```shell
export AWS_PROFILE=login-user1
export ORG_PROFILE=org-user1
./multi-account-wrapper.sh -r assume-role-readonly -f "Classic-Resource-Finder.sh"
```